### PR TITLE
Improved Exception Declarations

### DIFF
--- a/spyce/inc/spyce_exceptions.hpp
+++ b/spyce/inc/spyce_exceptions.hpp
@@ -1,7 +1,13 @@
 #pragma once
 
-#include <stdexcept>
+class SpyceException {
+    std::string str;
+public:
+    SpyceException(const std::string& str) : str(str) {}
+    SpyceException(const char *str) : str(std::string(str)) {}
+    const std::string& what() const {return str;};
+};
 
-struct FileNotFoundException : public std::runtime_error {
-    explicit FileNotFoundException() : std::runtime_error("File Not Found") {}
+struct FileNotFoundException : public SpyceException {
+    explicit FileNotFoundException() : SpyceException("File Not Found") {}
 };


### PR DESCRIPTION
This pull request rewrites the exception declaration function allowing them to be thrown as native Python Exceptions rather than System Errors. 

This stabilizes and simplifies exception handling in python. 

to test: 
compile code and see that it compiles. 

The following script will ensure it works: 
```
from spyce import spyce
s = spyce.spyce()

try:
    s.main_file = "file_that_doesnt_exist"
except Exception as e:
    print(e) ## File Not Found
```