### PR TITLE
T36 target info

### DIFF
--- a/spyce/inc/spyce.hpp
+++ b/spyce/inc/spyce.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <boost/python.hpp>
+
 #include "SpiceUsr.h"
 
 struct Frame {
@@ -9,7 +11,7 @@ struct Frame {
     Frame();
 };
 
-
+namespace py = boost::python;
 struct spyce {
     std::string file;
 
@@ -21,4 +23,6 @@ struct spyce {
 
     void add_kernel(std::string s);
     void remove_kernel(std::string s);
+
+    py::list get_objects();
 };

--- a/spyce/py_wrapper.cpp
+++ b/spyce/py_wrapper.cpp
@@ -24,7 +24,8 @@ BOOST_PYTHON_MODULE(spyce) {
     class_<spyce>("spyce")
         .add_property("main_file",&spyce::_get_file, &spyce::_set_file)
         .def("add_kernel", &spyce::add_kernel)
-        .def("remove_kernel", &spyce::remove_kernel);
+        .def("remove_kernel", &spyce::remove_kernel)
+        .def("get_objects", &spyce::get_objects);
 
     class_<Frame>("Frame")
         .def_readwrite("x",  &Frame::x)

--- a/spyce/spyce_main.cpp
+++ b/spyce/spyce_main.cpp
@@ -5,6 +5,8 @@
 #include "spyce.hpp"
 #include "spyce_exceptions.hpp"
 
+#define SPYCE_OBJECTS_MAX 100
+
 Frame::Frame(SpiceDouble *frame) {
     this->x  = frame[0];
     this->y  = frame[1];
@@ -41,35 +43,19 @@ void spyce::remove_kernel(std::string s) {
     unload_c(s.c_str());
 }
 
+namespace py = boost::python;
+py::list spyce::get_objects() {
+    //NOTE: this cell is static per the macro definition
+    SPICEINT_CELL(id_list, SPYCE_OBJECTS_MAX);
 
-// int main() {
-//     //furnsh_c("LMAP.DP7.bsp");
-//     const char *const file = "LMAP_FullTrajectory_ScienceExtension.bsp";
+    //have to reset the cell so data doesn't persist per call
+    scard_c(0, id_list)
 
-//     SPICEINT_CELL(id_list, 8);
-//     SPICEDOUBLE_CELL( cover, 1000 );
+    py::list ret_obj
+    if(_temp) spkobj_c(file.c_str(), &id_list);
+    for(int i = 0; i < card_c(&id_list); i++) {
+        ret_obj.append(SPICE_CELL_ELEM_I(&id_list, i));
+    }
 
-//     spkobj_c(file, &id_list);
-
-//     for(int i = 0; i < card_c(&id_list); i++) {
-//         SpiceInt obj = SPICE_CELL_ELEM_I(&id_list, i);
-
-//         scard_c(0, &cover); //reset coverage cell
-
-//         std::cout << "object id: " << obj << std::endl;
-
-//         spkcov_c(file, obj, &cover); //load coverage data of `obj` id
-
-//         int inv_num = wncard_c(&cover);
-
-//         std::cout << "number of intervals: " << inv_num << std::endl;
-
-//         double beg, end;
-
-//         wnfetd_c(&cover, 0, &beg, &end);
-
-//         std::cout << "start: " << beg << std::endl;
-//         std::cout << "end:   "   << end << std::endl;
-
-//     }
-// }
+    return ret_obj;
+}

--- a/spyce/spyce_main.cpp
+++ b/spyce/spyce_main.cpp
@@ -49,10 +49,10 @@ py::list spyce::get_objects() {
     SPICEINT_CELL(id_list, SPYCE_OBJECTS_MAX);
 
     //have to reset the cell so data doesn't persist per call
-    scard_c(0, id_list)
+    scard_c(0, &id_list);
 
-    py::list ret_obj
-    if(_temp) spkobj_c(file.c_str(), &id_list);
+    py::list ret_obj;
+    spkobj_c(file.c_str(), &id_list);
     for(int i = 0; i < card_c(&id_list); i++) {
         ret_obj.append(SPICE_CELL_ELEM_I(&id_list, i));
     }


### PR DESCRIPTION
Introduces the ability to get a list of available targets from a file. 

May want to rename the function name for better indication of what it does.

to test: 
load bsp file into the `.main_file` property of a spyce object, then call `.get_objects()` the output should be a list of available targets. 

bsp files will be available on google_drive