### PR TITLE
T80 NAIF ID Conversion

### DIFF
--- a/spyce/inc/spyce.hpp
+++ b/spyce/inc/spyce.hpp
@@ -19,6 +19,7 @@ struct spyce {
     spyce(std::string log_file);
 
     static int str_to_id(std::string naif_id);
+    static std::string id_to_str(int naif_id);
 
     //get and set for file.
     void _set_file(std::string s);

--- a/spyce/py_wrapper.cpp
+++ b/spyce/py_wrapper.cpp
@@ -37,10 +37,11 @@ BOOST_PYTHON_MODULE(spyce) {
     exception(IDNotFound);
     exception(InsufficientData);
 
+    def("str_to_id", &spyce::str_to_id);
+    def("id_to_str", &spyce::id_to_str);
+
     class_<spyce>("spyce")
         .add_property("main_file",&spyce::_get_file, &spyce::_set_file)
-        .def("str_to_id", &spyce::str_to_id)
-        .staticmethod("str_to_id")
         .def("add_kernel", &spyce::add_kernel)
         .def("remove_kernel", &spyce::remove_kernel)
         .def("get_objects", &spyce::get_objects)

--- a/spyce/spyce_main.cpp
+++ b/spyce/spyce_main.cpp
@@ -129,6 +129,7 @@ std::string spyce::id_to_str(int naif_id) {
     SpiceBoolean found;
 
     bodc2n_c(naif_id, NAIF_NAME_MAX, naif_name, &found);
+    check_spice_errors();
 
     if(!found)
         throw IDNotFoundException();

--- a/spyce/spyce_main.cpp
+++ b/spyce/spyce_main.cpp
@@ -7,6 +7,7 @@
 #include "spyce_exceptions.hpp"
 
 #define SPYCE_OBJECTS_MAX 100
+#define NAIF_NAME_MAX     33
 
 void check_spice_errors() {
     if(!failed_c()) return;
@@ -121,6 +122,18 @@ int spyce::str_to_id(std::string naif_id) {
         throw IDNotFoundException();
 
     return id_code;
+}
+
+std::string spyce::id_to_str(int naif_id) {
+    char naif_name[NAIF_NAME_MAX] = {0};
+    SpiceBoolean found;
+
+    bodc2n_c(naif_id, NAIF_NAME_MAX, naif_name, &found);
+
+    if(!found)
+        throw IDNotFoundException();
+
+    return std::string(naif_name);
 }
 
 Frame spyce::get_frame_data(int target_id, int observer_id, double e_time) {


### PR DESCRIPTION
One of the functions already existed but I've moved the declarations to make them more consistent.

to test:

from spyce import spyce 
spyce.id_to_str(399) # >earth
spyce.str_to_id("earth") # >399