### PR TITLE
Mistakenly did this work in a branch not based on dev.

### DIFF
--- a/FlaskServer.py
+++ b/FlaskServer.py
@@ -6,8 +6,9 @@ CURRENT_PATH = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 template_path = os.path.abspath(CURRENT_PATH + "/dist")
 app = Flask(__name__, template_folder=template_path, static_url_path='', static_folder=None)
 spy = spyce.spyce()
-main_kernel_filepath = ""
-TRAJECTORY_FOLDER = CURRENT_PATH + "/config/spyce_files/trajectory/"
+BSP_FILENAME = "spacecraft.bsp"
+TRAJECTORY_FOLDER = CURRENT_PATH + "/data/trajectory/"
+spy_loaded = False
 kernels = []
 main_subject = None
 main_subject_name = ""
@@ -89,6 +90,41 @@ def frame_to_dict(frame):
     frameDict['dy'] = frame.dy
     frameDict['dz'] = frame.dz
     return frameDict
+
+@app.route('/api/toJ2000', methods=['GET'])
+def toJ2000():
+    time = request.args.get("time")
+    if time == None:
+        abort(400)
+    try:
+        ret = spy.utc_to_et(time)
+        jsonObj = {}
+        jsonObj["UTC"] = time
+        jsonObj["J2000"] = ret
+        return jsonify(jsonObj)
+    except spyce.InvalidArgumentError:
+        abort(400)
+    except spyce.InternalError:
+        abort(500)
+
+@app.route('/api/toUTC', methods=['GET'])
+def toUTC():
+    time = request.args.get("time")
+    if time == None:
+        abort(400)
+    try:
+        time = float(time)
+        ret = spy.et_to_utc(time, "ISOC")
+        jsonObj = {}
+        jsonObj["UTC"] = ret
+        jsonObj["J2000"] = time
+        return jsonify(jsonObj)
+    except ValueError:
+        abort(400)
+    except spyce.InvalidArgumentError:
+        abort(400)
+    except spyce.InternalError:
+        abort(500)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Do not merge without first merging [PR#29](https://github.com/zawata/S19-Team2/pull/29)

To test:

In config, create config.json with the following contents:
{ "main_subject": -39, "subject_name": "LMAP", "kernels": [ "LMAP_FullTrajectory.bsp", "latest_leapseconds.tls.pc" ] }
In config/kernels, add LMAP_FullTrajectory.bsp from the team drive, and latest_leapseconds.tls.pc from slack.
Build and run
Make an http GET request to the /api/toUTC endpoint with a number argument. http://localhost:5000/api/toUTC?time=-60000000000 should give you
{ "J2000": -60000000000, "UTC": "98-09-04T01:19:19" }
Make an http get request to the /api/toJ2000 endpoint with an ISO 8601 string argument. http://localhost:5000/api/toJ2000?time=2012-12-25T3:00:00 should give you
{ "J2000": 409676467.18373287, "UTC": "2012-12-25T3:00:00" }