### PR TITLE
T71/T95 Get Coverage Windows

### DIFF
--- a/spyce/inc/spyce.hpp
+++ b/spyce/inc/spyce.hpp
@@ -29,6 +29,7 @@ struct spyce {
     void remove_kernel(std::string s);
 
     py::list get_objects();
+    py::list get_coverage_windows(int obj_id);
 
     Frame get_frame_data(int target_id, int observer_id, double e_time);
 };

--- a/spyce/py_wrapper.cpp
+++ b/spyce/py_wrapper.cpp
@@ -45,6 +45,7 @@ BOOST_PYTHON_MODULE(spyce) {
         .def("add_kernel", &spyce::add_kernel)
         .def("remove_kernel", &spyce::remove_kernel)
         .def("get_objects", &spyce::get_objects)
+        .def("get_coverage_windows", &spyce::get_coverage_windows)
         .def("get_frame_data", &spyce::get_frame_data);
 
     class_<Frame>("Frame")

--- a/spyce/spyce_main.cpp
+++ b/spyce/spyce_main.cpp
@@ -111,6 +111,33 @@ py::list spyce::get_objects() {
     return ret_obj;
 }
 
+namespace py = boost::python;
+py::list spyce::get_coverage_windows(int obj_id) {
+    //NOTE: this cell is static per the macro definition
+    SPICEDOUBLE_CELL(cover, SPYCE_OBJECTS_MAX);
+
+    //have to reset the cell so data doesn't persist per call
+    scard_c(0, &cover);
+    check_spice_errors();
+
+    py::list ret_obj;
+    spkcov_c(file.c_str(), obj_id, &cover); //load coverage data of `obj` id
+    check_spice_errors();
+
+    int limit = card_c(&cover) / 2;
+    check_spice_errors();
+
+    double beg, end;
+    for(int i = 0; i < limit; i++) {
+        wnfetd_c(&cover, i, &beg, &end);
+        check_spice_errors();
+
+        ret_obj.append(py::make_tuple(beg,end));
+    }
+
+    return ret_obj;
+}
+
 int spyce::str_to_id(std::string naif_id) {
     int  id_code;
     SpiceBoolean found;


### PR DESCRIPTION
returns a list of coverage windows for an object represented as a list of tuples of start and end times. 
test code: 
```
>>> from spyce import spyce
>>> s = spyce.spyce()
>>> s.main_file = "test_files/LMAP_FullTrajectory.bsp"
>>> s.get_coverage_windows(-39)
[(592316210.3249998, 641119250.3281932)]
```

