### PR TITLE
T93 Spyce refactor

### DIFF
--- a/spyce/inc/spyce.hpp
+++ b/spyce/inc/spyce.hpp
@@ -11,18 +11,20 @@ struct Frame {
     Frame();
 };
 
-void init();
+namespace py = boost::python;
 
-int str_to_id(std::string naif_id);
-std::string id_to_str(int naif_id);
+void        spyce_init();
 
-double utc_to_et(std::string date);
-std::string et_to_utc(double et, std::string format);
+int         spyce_str_to_id(std::string naif_id);
+std::string spyce_id_to_str(int naif_id);
 
-void add_kernel(std::string s);
-void remove_kernel(std::string s);
+double      spyce_utc_to_et(std::string date);
+std::string spyce_et_to_utc(double et, std::string format);
 
-py::list get_objects(std::string file);
-py::list get_coverage_windows(std::string file, int obj_id);
+void        spyce_add_kernel(std::string s);
+void        spyce_remove_kernel(std::string s);
 
-Frame get_frame_data(int target_id, int observer_id, double e_time);
+py::list    spyce_get_objects(std::string file);
+py::list    spyce_get_coverage_windows(std::string file, int obj_id);
+
+Frame       spyce_get_frame_data(int target_id, int observer_id, double e_time);

--- a/spyce/inc/spyce.hpp
+++ b/spyce/inc/spyce.hpp
@@ -11,28 +11,18 @@ struct Frame {
     Frame();
 };
 
-namespace py = boost::python;
-struct spyce {
-    std::string file;
+void init();
 
-    spyce();
-    spyce(std::string log_file);
+int str_to_id(std::string naif_id);
+std::string id_to_str(int naif_id);
 
-    static int str_to_id(std::string naif_id);
-    static std::string id_to_str(int naif_id);
+double utc_to_et(std::string date);
+std::string et_to_utc(double et, std::string format);
 
-    //get and set for file.
-    void _set_file(std::string s);
-    std::string _get_file();
+void add_kernel(std::string s);
+void remove_kernel(std::string s);
 
-    void add_kernel(std::string s);
-    void remove_kernel(std::string s);
+py::list get_objects(std::string file);
+py::list get_coverage_windows(std::string file, int obj_id);
 
-    double utc_to_et(std::string date);
-    std::string et_to_utc(double et, std::string format);
-
-    py::list get_objects();
-    py::list get_coverage_windows(int obj_id);
-
-    Frame get_frame_data(int target_id, int observer_id, double e_time);
-};
+Frame get_frame_data(int target_id, int observer_id, double e_time);

--- a/spyce/inc/spyce_exceptions.hpp
+++ b/spyce/inc/spyce_exceptions.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
+/**
+ * Simplified Exception Class Declaration Macros
+ **/
 #define build_exception_msg(NAME, MSG) struct NAME ## Exception : public SpyceException { \
     explicit NAME ## Exception() : SpyceException(MSG) {}}
 
 #define build_exception(NAME) struct NAME ## Exception : public SpyceException { \
     explicit NAME ## Exception(std::string err) : SpyceException(err) {}}
 
+/**
+ * SpyceException Base Class
+ **/
 class SpyceException {
     std::string str;
 public:
@@ -14,6 +20,9 @@ public:
     const std::string& what() const {return str;};
 };
 
+/**
+ * Exception Class Declarations
+ **/
 build_exception_msg(FileNotFound, "File Not Found");
 build_exception(InvalidFile);
 build_exception(InvalidArgument);

--- a/spyce/py_wrapper.cpp
+++ b/spyce/py_wrapper.cpp
@@ -3,6 +3,9 @@
 #include "spyce_exceptions.hpp"
 #include "spyce.hpp"
 
+/**
+ * Simplified exception declaration function
+ **/
 namespace py = boost::python;
 template <class E> void exception_(const char *name) {
     //check that class type E inherits from SpyceException(to Ensure it has a `what` call)
@@ -25,11 +28,24 @@ template <class E> void exception_(const char *name) {
             PyErr_SetString(exc, e.what().c_str());
         });
 }
+
+/**
+ * Further simplified Exception Macro
+ **/
 #define exception(NAME) exception_<NAME ## Exception>(#NAME"Error")
 
 BOOST_PYTHON_MODULE(spyce) {
     using namespace boost::python;
 
+    /**
+     * Initialization
+     **/
+    init();
+
+
+    /**
+     * Declarations
+     **/
     exception(FileNotFound);
     exception(InvalidFile);
     exception(InvalidArgument);
@@ -37,24 +53,25 @@ BOOST_PYTHON_MODULE(spyce) {
     exception(IDNotFound);
     exception(InsufficientData);
 
-    def("str_to_id", &spyce::str_to_id);
-    def("id_to_str", &spyce::id_to_str);
+    def("str_to_id", &str_to_id);
+    def("id_to_str", &id_to_str);
 
-    class_<spyce>("spyce")
-        .add_property("main_file",&spyce::_get_file, &spyce::_set_file)
-        .def("add_kernel", &spyce::add_kernel)
-        .def("remove_kernel", &spyce::remove_kernel)
-        .def("utc_to_et", &spyce::utc_to_et)
-        .def("et_to_utc", &spyce::et_to_utc)
-        .def("get_objects", &spyce::get_objects)
-        .def("get_coverage_windows", &spyce::get_coverage_windows)
-        .def("get_frame_data", &spyce::get_frame_data);
+    def("utc_to_et", &spyce::utc_to_et);
+    def("et_to_utc", &spyce::et_to_utc);
+
+    def("add_kernel", &add_kernel)
+    def("remove_kernel", &remove_kernel)
+
+    def("get_objects", &get_objects)
+    def("get_coverage_windows", &spyce::get_coverage_windows)
+
+    def("get_frame_data", &get_frame_data);
 
     class_<Frame>("Frame")
-        .def_readwrite("x",  &Frame::x)
-        .def_readwrite("y",  &Frame::y)
-        .def_readwrite("z",  &Frame::z)
-        .def_readwrite("dx", &Frame::dx)
-        .def_readwrite("dy", &Frame::dy)
-        .def_readwrite("dz", &Frame::dz);
+        .def_readonly("x",  &Frame::x)
+        .def_readonly("y",  &Frame::y)
+        .def_readonly("z",  &Frame::z)
+        .def_readonly("dx", &Frame::dx)
+        .def_readonly("dy", &Frame::dy)
+        .def_readonly("dz", &Frame::dz);
 }

--- a/spyce/py_wrapper.cpp
+++ b/spyce/py_wrapper.cpp
@@ -40,8 +40,7 @@ BOOST_PYTHON_MODULE(spyce) {
     /**
      * Initialization
      **/
-    init();
-
+    spyce_init();
 
     /**
      * Declarations
@@ -53,19 +52,19 @@ BOOST_PYTHON_MODULE(spyce) {
     exception(IDNotFound);
     exception(InsufficientData);
 
-    def("str_to_id", &str_to_id);
-    def("id_to_str", &id_to_str);
+    def("str_to_id", &spyce_str_to_id);
+    def("id_to_str", &spyce_id_to_str);
 
-    def("utc_to_et", &spyce::utc_to_et);
-    def("et_to_utc", &spyce::et_to_utc);
+    def("utc_to_et", &spyce_utc_to_et);
+    def("et_to_utc", &spyce_et_to_utc);
 
-    def("add_kernel", &add_kernel)
-    def("remove_kernel", &remove_kernel)
+    def("add_kernel", &spyce_add_kernel);
+    def("remove_kernel", &spyce_remove_kernel);
 
-    def("get_objects", &get_objects)
-    def("get_coverage_windows", &spyce::get_coverage_windows)
+    def("get_objects", &spyce_get_objects);
+    def("get_coverage_windows", &spyce_get_coverage_windows);
 
-    def("get_frame_data", &get_frame_data);
+    def("get_frame_data", &spyce_get_frame_data);
 
     class_<Frame>("Frame")
         .def_readonly("x",  &Frame::x)

--- a/spyce/spyce_main.cpp
+++ b/spyce/spyce_main.cpp
@@ -68,7 +68,7 @@ Frame::Frame() {
 /**
  * Spyce
  **/
-void init() {
+void spyce_init() {
     // Error Handling
     //https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/error.html
     erract_c("SET", 0, (SpiceChar *)"RETURN"); // disable "exit on error"
@@ -77,7 +77,7 @@ void init() {
 }
 
 //Helper Functions
-int spyce::str_to_id(std::string naif_id) {
+int spyce_str_to_id(std::string naif_id) {
     int  id_code;
     SpiceBoolean found;
 
@@ -90,7 +90,7 @@ int spyce::str_to_id(std::string naif_id) {
     return id_code;
 }
 
-std::string spyce::id_to_str(int naif_id) {
+std::string spyce_id_to_str(int naif_id) {
     char naif_name[NAIF_NAME_MAX] = {0};
     SpiceBoolean found;
 
@@ -103,7 +103,7 @@ std::string spyce::id_to_str(int naif_id) {
     return std::string(naif_name);
 }
 
-double spyce::utc_to_et(std::string date) {
+double spyce_utc_to_et(std::string date) {
     //acceptable date formats:
     //https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/utc2et_c.html#Examples
 
@@ -114,7 +114,7 @@ double spyce::utc_to_et(std::string date) {
     return et;
 }
 
-std::string spyce::et_to_utc(double et, std::string format) {
+std::string spyce_et_to_utc(double et, std::string format) {
     //acceptable date formats:
     //https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/utc2et_c.html#Examples
 
@@ -127,7 +127,7 @@ std::string spyce::et_to_utc(double et, std::string format) {
 
 //File Operations
 namespace py = boost::python;
-py::list spyce::get_objects(std::string file) {
+py::list spyce_get_objects(std::string file) {
     //NOTE: this cell is static per the macro definition
     SPICEINT_CELL(id_list, SPYCE_OBJECTS_MAX);
 
@@ -150,7 +150,7 @@ py::list spyce::get_objects(std::string file) {
 }
 
 namespace py = boost::python;
-py::list spyce::get_coverage_windows(std::string file, int obj_id) {
+py::list spyce_get_coverage_windows(std::string file, int obj_id) {
     //NOTE: this cell is static per the macro definition
     SPICEDOUBLE_CELL(cover, SPYCE_OBJECTS_MAX);
 
@@ -177,16 +177,16 @@ py::list spyce::get_coverage_windows(std::string file, int obj_id) {
 }
 
 //Kernel functions
-void spyce::add_kernel(std::string s) {
+void spyce_add_kernel(std::string s) {
     furnsh_c(s.c_str());
     check_spice_errors();
 }
 
-void spyce::remove_kernel(std::string s) {
+void spyce_remove_kernel(std::string s) {
     unload_c(s.c_str());
     check_spice_errors();
 }
-Frame spyce::get_frame_data(int target_id, int observer_id, double e_time) {
+Frame spyce_get_frame_data(int target_id, int observer_id, double e_time) {
     SpiceDouble frame[6] = {0};
     SpiceDouble lt;
 


### PR DESCRIPTION
remove the `main_file` property, 
update functions to take file parameter
removes the spyce class as it is a misnomer with the spyce architecture
various code cleanups

Testing:
```
>>> from spyce import spyce
>>> spyce.id_to_str(399)
'EARTH'
>>> spyce.id_to_str(39)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
spyce.spyce.IDNotFoundError: ID Not Found
>>> spyce.add_kernel(test_files/leapseconds.tls)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'test_files' is not defined
>>> spyce.add_kernel("test_files/leapseconds.tls")
>>> spyce.get_objects("test_files/LMAP_FullTrajectory.bsp")
[-39]
>>> spyce.get_coverage_windows("test_files/LMAP_FullTrajectory.bsp", -39)
[(592316210.3249998, 641119250.3281932)]

```