### PR TITLE
T96 coverage windows2

### DIFF
--- a/FlaskServer.py
+++ b/FlaskServer.py
@@ -54,25 +54,20 @@ def get_coverage_window(object_identifier):
     coverage_window = {}
     NAIF_id = None
     try:
-        NAIF_id = int(object_identifier)
-        if NAIF_id != main_subject:
-            try:
-                spyce.id_to_str(NAIF_id)
-            except spyce.IDNotFoundError:
-                abort(404, "Invalid object id")
-    except ValueError:
-        #object_identifier is name.
-        pass
+        #check if arg is ID or name.
+        try:
+            NAIF_id = int(object_identifier)
+        except ValueError:
+            if object_identifier == main_subject_name:
+                NAIF_id = main_subject
+            else:
+                NAIF_id = spyce.str_to_id(object_identifier)
 
-    if NAIF_id == None:
-        name = object_identifier
-        if name == main_subject_name:
-            NAIF_id = main_subject
-        else:
-            try:
-                NAIF_id = spyce.str_to_id(name)
-            except spyce.IDNotFoundError:
-                abort(404, "Invalid object name")
+        #check if the id exists
+        if NAIF_id != main_subject:
+            spyce.id_to_str(NAIF_id)
+    except spyce.IDNotFoundError:
+        abort(404, "Object not found.")
 
     windows_piecewise = []
     for k in kernels:
@@ -83,9 +78,12 @@ def get_coverage_window(object_identifier):
         except spyce.InternalError:
             #object does not exist in this kernel.
             pass
-    coverage_window['start'] = windows_piecewise[0][0]
-    coverage_window['end'] = windows_piecewise[-1][1]
-    return jsonify(coverage_window)
+    if len(windows_piecewise) > 0:
+        coverage_window['start'] = windows_piecewise[0][0]
+        coverage_window['end'] = windows_piecewise[-1][1]
+        return jsonify(coverage_window)
+    else:
+        abort(404, "No Coverage found")
 
 def get_all_objects(time=None):
     objects = []

--- a/FlaskServer.py
+++ b/FlaskServer.py
@@ -49,31 +49,43 @@ def handle_get_objects_request():
 def get_file(filename):
     return send_from_directory('dist', filename)
 
-@app.route('/api/all_coverage_windows')
-def get_coverage_windows():
-    windows = {}
-    objects = get_all_objects()
+@app.route('/api/objects/<object_identifier>/coverage', methods=['GET'])
+def get_coverage_window(object_identifier):
+    coverage_window = {}
+    NAIF_id = None
+    try:
+        NAIF_id = int(object_identifier)
+        if NAIF_id != main_subject:
+            try:
+                spyce.id_to_str(NAIF_id)
+            except spyce.IDNotFoundError:
+                abort(404, "Invalid object id")
+    except ValueError:
+        #object_identifier is name.
+        pass
+
+    if NAIF_id == None:
+        name = object_identifier
+        if name == main_subject_name:
+            NAIF_id = main_subject
+        else:
+            try:
+                NAIF_id = spyce.str_to_id(name)
+            except spyce.IDNotFoundError:
+                abort(404, "Invalid object name")
+
+    windows_piecewise = []
     for k in kernels:
         spy.main_file = k
-
-        for o in objects:
-            try:
-                print("KERNEL: %s, OBJECT: %s" % (k, o))
-                object_id = o['id']
-                windowsSoFar = windows.get(object_id, [])
-                windowsSoFar += spy.get_coverage_windows(o["id"])
-                windowsSoFar.sort(key=lambda x: x[0])
-                windows[object_id] = windowsSoFar
-            except spyce.InternalError:
-                print("INTERNAL ERROR")
-                #object does not exist in this kernel.
-                pass
-    for o in objects:
-        print("OID: ", o['id'])
-        print("WINDOWS: ", windows)
-        c_ws = windows[o['id']]
-        o['coverage_window'] = (c_ws[0][0], c_ws[-1][1])
-    return jsonify(objects)
+        try:
+            windows_piecewise += spy.get_coverage_windows(NAIF_id)
+            windows_piecewise.sort(key=lambda x: x[0])
+        except spyce.InternalError:
+            #object does not exist in this kernel.
+            pass
+    coverage_window['start'] = windows_piecewise[0][0]
+    coverage_window['end'] = windows_piecewise[-1][1]
+    return jsonify(coverage_window)
 
 def get_all_objects(time=None):
     objects = []


### PR DESCRIPTION
Added an endpoint for fetching coverage windows.

To test: make an GET request to the /api/objects/<object_identifier>/coverage endpoint.

object identifier can be an NAIF ID, or the all-caps SPICE name for an object.

