### PR TITLE
Fix speed slider value not sticking on the slider

### DIFF
--- a/web/components/sliders/SpeedSlider.js
+++ b/web/components/sliders/SpeedSlider.js
@@ -30,6 +30,7 @@ class SpeedSlider extends Component {
 
   onChange = ([newSpeed]) => {
     set_update_frequency(newSpeed);
+    this.props.updateAnimationSpeed(newSpeed);
   }
 
   renderSpeedHeading(speed){


### PR DESCRIPTION
To Test:
- Open controls menu
- change speed slider
- close and reopen controls menu
- speed slider should be at the value it was set to earlier